### PR TITLE
Add coat of arms files for 17 new countries.

### DIFF
--- a/common/coat_of_arms/coat_of_arms/aqu_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/aqu_countries.txt
@@ -1,0 +1,14 @@
+AQU = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/bat_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/bat_countries.txt
@@ -1,0 +1,14 @@
+BAT = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/bok_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/bok_countries.txt
@@ -1,0 +1,14 @@
+BOK = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/cel_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/cel_countries.txt
@@ -1,0 +1,14 @@
+CEL = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/cis_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/cis_countries.txt
@@ -1,0 +1,14 @@
+CIS = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/dan_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/dan_countries.txt
@@ -1,0 +1,14 @@
+DAN = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/gll_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/gll_countries.txt
@@ -1,0 +1,14 @@
+GLL = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/lug_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/lug_countries.txt
@@ -1,0 +1,14 @@
+LUG = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/mgc_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/mgc_countries.txt
@@ -1,0 +1,14 @@
+MGC = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/nwc_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/nwc_countries.txt
@@ -1,0 +1,14 @@
+NWC = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/pry_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/pry_countries.txt
@@ -1,0 +1,14 @@
+PRY = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/sas_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/sas_countries.txt
@@ -1,0 +1,14 @@
+SAS = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/sue_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/sue_countries.txt
@@ -1,0 +1,14 @@
+SUE = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/sve_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/sve_countries.txt
@@ -1,0 +1,14 @@
+SVE = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/sxn_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/sxn_countries.txt
@@ -1,0 +1,14 @@
+SXN = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/trt_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/trt_countries.txt
@@ -1,0 +1,14 @@
+TRT = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}

--- a/common/coat_of_arms/coat_of_arms/tsc_countries.txt
+++ b/common/coat_of_arms/coat_of_arms/tsc_countries.txt
@@ -1,0 +1,14 @@
+TSC = {
+	pattern = "pattern_solid.tga"
+	color1 = "red"
+
+	colored_emblem = {
+		texture = "ce_solid.dds" # Regular Border
+		color1 = "white"
+		color2 = "white"
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.05 } }
+		instance = { scale = { 1.0 0.1 } position = { 0.5 0.95 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.033 0.5 } }
+		instance = { scale = { 0.066 1.0 } position = { 0.967 0.5 } }
+	}
+}


### PR DESCRIPTION
This change adds the coat of arms definition files for the following new countries:
- Gallic Republic
- Batavian Republic
- Kingdom of Aquitania
- League of Prydain
- Kingdom of Celtiberia
- Republic of Tartessos
- Kingdom of Suebia
- Kingdom of Saxonia
- Cisalpine Republic
- Republic of Tuscia
- Magna Graecia League
- Kingdom of the Danes
- Norrvegr Confederacy
- Kingdom of Svealand
- Bohemian Kingdom
- Kingdom of the Lugii
- Sassanian Shahdom

The files are created in the `common/coat_of_arms/coat_of_arms/` directory, following the existing naming convention. A placeholder coat of arms definition is used for each country.